### PR TITLE
fix: eventually-openapi config so that it runs in firebase emulator

### DIFF
--- a/libs/eventually-openapi/src/config.ts
+++ b/libs/eventually-openapi/src/config.ts
@@ -23,7 +23,7 @@ const { PORT, OAS_UI } = process.env;
  */
 export const config = extend(
   {
-    port: Number.parseInt(PORT || "3000"),
+    port: parseInt(PORT || "3000") || 3000,
     oas_ui: (OAS_UI as OAS_UI) || "SwaggerUI"
   },
   Schema,


### PR DESCRIPTION
The error occurs because the emulator uses pipes (at least on windows) and parseInt returns an NaN which fails schema validation and causes crash.